### PR TITLE
Fix signal handling for forked children

### DIFF
--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -88,12 +88,13 @@ void	exec_subshell(t_token_list *tokens, t_shell *shell, t_ast *node)
 	pid = fork();
 	if (pid < 0)
 		exit_perror("fork");
-	if (pid == 0)
-	{
-		executor(tokens, shell, node);
-		clean_all(shell->tokens, shell->ast, &shell->env);
-		exit(shell->last_status);
-	}
+        if (pid == 0)
+        {
+                setup_signals_exec();
+                executor(tokens, shell, node);
+                clean_all(shell->tokens, shell->ast, &shell->env);
+                exit(shell->last_status);
+        }
 	if (waitpid(pid, &status, 0) < 0)
 		exit_perror("waitpid");
 	shell->last_status = WEXITSTATUS(status);

--- a/src/executor/executor_dispatch.c
+++ b/src/executor/executor_dispatch.c
@@ -17,16 +17,22 @@ int	exec_dispatch(char **args, t_env *env, char **envp)
 	int		status;
 	pid_t	pid;
 
-	if (is_builtin(args[0]))
-		return (run_builtin(args, env));
-	pid = fork();
-	if (pid < 0)
-		exit_perror("fork failed");
-	if (pid == 0)
-		execve_with_path(args, env, envp);
-	if (waitpid(pid, &status, 0) < 0)
-		exit_perror("waitpid failed");
-	return (WEXITSTATUS(status));
+        if (is_builtin(args[0]))
+                return (run_builtin(args, env));
+        signal(SIGINT, SIG_IGN);
+        signal(SIGQUIT, SIG_IGN);
+        pid = fork();
+        if (pid < 0)
+                exit_perror("fork failed");
+        if (pid == 0)
+        {
+                setup_signals_exec();
+                execve_with_path(args, env, envp);
+        }
+        if (waitpid(pid, &status, 0) < 0)
+                exit_perror("waitpid failed");
+        setup_signals_prompt();
+        return (WEXITSTATUS(status));
 }
 
 void	execve_with_path(char **args, t_env *env, char **envp)

--- a/src/executor/executor_pipe.c
+++ b/src/executor/executor_pipe.c
@@ -14,6 +14,7 @@
 
 void	handle_left_child(int *fd, t_shell *shell, t_ast *node)
 {
+        setup_signals_exec();
 	dup2(fd[1], STDOUT_FILENO);
 	close(fd[0]);
 	close(fd[1]);
@@ -24,6 +25,7 @@ void	handle_left_child(int *fd, t_shell *shell, t_ast *node)
 
 void	handle_right_child(int *fd, t_shell *shell, t_ast *node)
 {
+        setup_signals_exec();
 	dup2(fd[0], STDIN_FILENO);
 	close(fd[1]);
 	close(fd[0]);


### PR DESCRIPTION
## Summary
- reset SIGINT/SIGQUIT before forking external commands
- install execution signal handlers for pipeline and subshell children
- restore prompt signal handlers after external command execution

## Testing
- `make fclean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_683f9eb18678833095f4536d224ad4fd