### PR TITLE
Handle heredoc signals

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -357,6 +357,7 @@ void			handle_sigint_exec(int sig);
 void			handle_sigquit_exec(int sig);
 void			handle_sigeof_heredoc(char *delim);
 void			handle_sigint_heredoc(int sig);
+void			setup_signals_heredoc(void);
 
 // setup_signals_exec
 void			setup_signals_exec(void);

--- a/src/heredoc/heredoc.c
+++ b/src/heredoc/heredoc.c
@@ -57,8 +57,14 @@ int	process_heredoc(char *delim, int no_expand, t_env *env, t_shell *sh)
 
 	if (pipe(fds) < 0)
 		exit_perror("pipe");
+        setup_signals_heredoc();
 	while (1)
 	{
+                if (g_signal_status == 130)
+                {
+                        close(fds[1]);
+                        return (-1);
+                }
 		line = readline("> ");
 		if (!line || ft_strcmp(line, delim) == 0)
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -85,6 +85,14 @@ void	parser(t_token_list *tokens, t_shell *shell)
 	ast = parse_logical(&tokens->head);
 	shell->ast = ast;
 	prepare_heredocs(shell->ast, shell);
+        if (g_signal_status == 130)
+        {
+                token_list_free(tokens);
+                ast_free(shell->ast);
+                shell->ast = NULL;
+                shell->tokens = NULL;
+                return ;
+        }
 	executor(tokens, shell, ast);
 	token_list_free(tokens);
 	ast_free(shell->ast);

--- a/src/signal/setup_signals_heredoc.c
+++ b/src/signal/setup_signals_heredoc.c
@@ -12,10 +12,16 @@
 
 #include "../../include/minishell.h"
 
-// void	setup_signals_heredoc(void)
-// {
-//
-// }
+void    setup_signals_heredoc(void)
+{
+        t_sig   sa_int;
+
+        sa_int.sa_handler = handle_sigint_heredoc;
+        sigemptyset(&sa_int.sa_mask);
+        sa_int.sa_flags = 0;
+        sigaction(SIGINT, &sa_int, NULL);
+        signal(SIGQUIT, SIG_IGN);
+}
 
 void	handle_sigeof_heredoc(char *delim)
 {


### PR DESCRIPTION
## Summary
- add `setup_signals_heredoc` implementation
- start heredoc with signal setup and abort on SIGINT
- skip command execution when heredoc is interrupted

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68438dd2fdfc8330b35614b0cd090bbf